### PR TITLE
Strategia support

### DIFF
--- a/Core Missions/KerbinSpaceStation.cfg
+++ b/Core Missions/KerbinSpaceStation.cfg
@@ -1,7 +1,0 @@
-//A file to hold all Contract Groups used in Kerbin Space Station, so I don't have to update all the files every time a new version of CC comes out.
-CONTRACT_GROUP
-{
-    name = KerbinSpaceStation
-    minVersion = 1.7.5
-    disabledContractType = StationContract
-}

--- a/Core Missions/StationCore.cfg
+++ b/Core Missions/StationCore.cfg
@@ -1,7 +1,7 @@
 CONTRACT_TYPE
 {
     name = StationCore
-    group = KerbinSpaceStation
+    group = UsefulSpaceStations
     title = Launch the @/targetBody1 Space Station!
     description = In order to aid our efforts of exploring @/targetBody1 we'd like you to launch a space station.
     synopsis = Launch the @/targetBody1 Space Station!

--- a/MaintenanceMissions/KerbinSpaceStation.cfg
+++ b/MaintenanceMissions/KerbinSpaceStation.cfg
@@ -2,5 +2,6 @@
 CONTRACT_GROUP
 {
     name = UsefulSpaceStations
+    displayName = Kerbin Space Station
 	minVersion = 1.8.0
 }

--- a/Patches/Strategia.cfg
+++ b/Patches/Strategia.cfg
@@ -1,0 +1,11 @@
+// Changes Strategia strategies to use Kerbin Space Station
+//   Author: nightingale
+
+@STRATEGY_LEVEL_EXPAND[EngineerFocus]:NEEDS[Strategia]
+{
+    @EFFECT[CurrencyOperationByContract]
+    {
+        contractType = UsefulSpaceStations
+    }
+}
+


### PR DESCRIPTION
Added support for [Strategia](https://github.com/jrossignol/Strategia).  Changes include:
- Consolidated under a single contract group (it was easier to do it under UsefulSpaceStations).
- Added a display name to the contract group (used the name of the contract pack).
- Added a module manager patch to affect the relevant Strategia strategy.
