### PR TITLE
Fix compatibility issue with Kerbalism

### DIFF
--- a/Core Missions/StationCore.cfg
+++ b/Core Missions/StationCore.cfg
@@ -250,6 +250,14 @@ type = Any
 	checkOnActiveContract = false
 	partModule = StationScienceModule
 }
+
+    REQUIREMENT:NEEDS[Kerbalism]
+{
+    name = PartModuleUnlocked
+    type = PartModuleUnlocked
+    checkOnActiveContract = false
+    partModule = Laboratory
+}
 }
 REQUIREMENT
 {


### PR DESCRIPTION
Kerbalism uses Laboratory instead of ModuleScienceLab, causing the
requirement for StationCore to never be met.